### PR TITLE
Moved cm_dontconvertlink to a-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ _cm-image_:
 | editable                        | replace `editable` attribute           | true          |
 | placeholder                     | use an placeholder image               | false         |
 | ...any other mj-image attribute |                                        |               |
+
+This is a test.

--- a/src/cm-image.js
+++ b/src/cm-image.js
@@ -130,7 +130,6 @@ class CmImage extends BodyComponent {
             width: this.getContentWidth(),
             editable: this.getAttribute('editable') === 'true' || null,
             cm_dontimportimage: this.getAttribute('disable-importing'),
-            cm_dontconvertlink: this.getAttribute('disable-tracking'),
           })}
         />
       `
@@ -143,6 +142,7 @@ class CmImage extends BodyComponent {
               target: this.getAttribute('target'),
               rel: this.getAttribute('rel'),
               name: this.getAttribute('name'),
+              cm_dontconvertlink: this.getAttribute('disable-tracking'),
             })}
           >
             ${img}


### PR DESCRIPTION
`cm_dontconvertlink` shouldn't be added to the image tag.
Instead it should be added to the a-tag so Campaign Monitor actually don't convert the link.